### PR TITLE
修复Base64解码问题，提升链接解析准确性。

### DIFF
--- a/js/faster-bing.js
+++ b/js/faster-bing.js
@@ -113,7 +113,8 @@
         urlBase64 = urlBase64.replace(/^a1/, '');
         let realUrl = ''
         try {
-            realUrl = atob(urlBase64);
+            // 还原Base64 URL编码中的特殊字符以便解码
+            realUrl = atob(urlBase64.replace(/_/g, '/').replace(/-/g, '+'));
         } catch (error) {
             return null;
         }


### PR DESCRIPTION
修改了 `redirect2RealUrl` 函数中的Base64解码逻辑，修复了由于Bing对Base64内容中 "/" 和 "+" 字符的处理（替换为 "_" 和 "-"）导致的解码失败问题。

---

Fix Base64 decoding issue to improve link parsing accuracy

Updated the Base64 decoding logic in the `redirect2RealUrl` function to handle Bing's replacement of "/" and "+" characters in Base64 content with "_" and "-".