### PR TITLE
修复Microsoft Edge浏览器中Bing搜索结果页面的中转链接替换问题

### DIFF
--- a/js/faster-bing.js
+++ b/js/faster-bing.js
@@ -219,11 +219,14 @@
         console.table(details);
     }
 
-    const result = convertBingRedirectUrls();
+    // 确保页面加载完成后能够正常修改 DOM
+    window.onload = () => {
+        const result = convertBingRedirectUrls();
 
-    console.log(logo);
+        console.log(logo);
 
-    if (Config.log.enable) {
-        log(result)
-    }
+        if (Config.log.enable) {
+            log(result)
+        }
+    };
 })();


### PR DESCRIPTION
修复：在Microsoft Edge浏览器中，Bing搜索结果页面的中转链接没有被正确替换

问题描述：
在使用Microsoft Edge浏览器进行Bing搜索时，搜索结果页面的中转链接没有被正确替换。刷新页面后链接会正常替换。

修复方法：
调整了脚本逻辑，使用window.onload确保在Microsoft Edge浏览器中Bing的搜索结果页面的中转链接能够立即正确替换，而不需要刷新页面。

---

Fix: Incorrect replacement of redirect links in Bing search results page on Microsoft Edge

Issue Description:
When using Microsoft Edge browser to perform Bing searches, the redirect links on the search results page were not replaced correctly. Refreshing the page would result in correct replacement.

Fix:
Adjusted the script logic using window.onload to ensure that the redirect links on the Bing search results page are correctly replaced immediately when using Microsoft Edge browser, without needing a page refresh.